### PR TITLE
🐛 Disabled cURL SSL verification in AmazonScraper

### DIFF
--- a/Tools/AmazonScraper/functions.php
+++ b/Tools/AmazonScraper/functions.php
@@ -7,7 +7,10 @@
  * This script is part of the PALEObooks scraping tool.
 */
 
+$ignoreSslErrors = false;
+
 function getJson($url, $attempt = 1) {
+    global $ignoreSslErrors;
     sleep(rand(1, 3));
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
@@ -16,12 +19,15 @@ function getJson($url, $attempt = 1) {
     curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 60);
     curl_setopt($ch, CURLOPT_TIMEOUT, 60);
-    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, !$ignoreSslErrors);
 
     $result = curl_exec($ch);
 
     if (curl_errno($ch) || curl_getinfo($ch, CURLINFO_HTTP_CODE) !== 200 || json_decode($result) === null) {
         logMessage('API request failed, attempt ' . (($attempt - 1) % 3 + 1) . ' of 3.');
+        if (curl_errno($ch) === 60) {
+            askCertificateCheck();
+        }
         if ($attempt % 3 === 0) {
             $retry = askNewIp($attempt > 3);
             if (!$retry) {
@@ -52,4 +58,11 @@ function askNewIp($suggestSkip = false) {
         return false;
     }
     return true;
+}
+
+function askCertificateCheck() {
+    global $ignoreSslErrors;
+    logMessage('There seems to be an issue with the SSL certificate of '. ALS_HOST . '. Please check that it is valid, and press enter to continue anyway.', false);
+    readline();
+    $ignoreSslErrors = true;
 }


### PR DESCRIPTION
Doing some tests with @Luca10info we encountered an issue doing the requests to the Amazon API; cURL was returning the error number 60, according to the [docs](https://curl.se/docs/manpage.html) it is the error **CURLE_PEER_FAILED_VERIFICATION**, basically an issue during the verification of the remote server SSL certificate.

The certificate on [www.adozionilibriscolastici.it](https://www.adozionilibriscolastici.it/) seems to be okay, so probably cURL is missing the CA bundle used by Amazon between its trusted certificates.

To avoid further issues in the future usage of the script, I simply propose to disable the SSL verification in the Amazon scraper. Is not a good practice, but I'm not too woried about man-in-the-middle or other kinds of attack on that domain. We use these APIs just to get the books list, we never send private data, so in the worst scenario we could just get a wrong book list. But I think it is very unlikely that this will happen.